### PR TITLE
Goodbye input prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ And use it inside your container:
 
 ```javascript
 <InputBoxDoneTyping
-  inputId="input-box-done-typing"
-  inputClassName="form-control"
-  inputPlaceholder="Start typing ..."
-  inputDefaultValue="lon"
-  inputOnChange={(value) => { console.log('inputOnChange:', value); } }
-  inputDoneTyping={(value) => { console.log('inputDoneTyping:', value); } }
+  id="input-box-done-typing"
+  className="form-control"
+  placeholder="Start typing ..."
+  defaultValue="lon"
+  autoComplete="on"
+  onChange={(value) => { console.log('onChange:', value); } }
+  doneTyping={(value) => { console.log('doneTyping:', value); } }
   doneTypingInterval={2000}
   />
 ```
@@ -34,13 +35,13 @@ And use it inside your container:
 
 Name | Type | Required | Default | Options
 --- | --- | --- | --- | ---
-`inputId` | `string` | no | - | -
-`inputClassName` | `string` | no | - | -
-`inputPlaceholder` | `string` | no | - | -
-`inputDefaultValue` | `string` | no | - | -
-`inputAutoComplete` | `string` | no | on | ['on', 'off']
-`inputOnChange` | `function` | no | - | -
-`inputDoneTyping` | `function` | yes | - | -
+`id` | `string` | no | - | -
+`className` | `string` | no | - | -
+`placeholder` | `string` | no | - | -
+`defaultValue` | `string` | no | - | -
+`autoComplete` | `string` | no | on | ['on', 'off']
+`onChange` | `function` | no | - | -
+`doneTyping` | `function` | yes | - | -
 `doneTypingInterval` | `number` | no | 500 (milliseconds) | -
 
 ## Demo

--- a/demo/index.js
+++ b/demo/index.js
@@ -7,24 +7,24 @@ const App = (props) => {
     <div className="container">
       <div className="row">
         <InputBoxDoneTyping
-          inputDefaultValue="lon"
-          inputOnChange={(value) => { console.log('inputOnChange:', value); } }
-          inputDoneTyping={(value) => { console.log('inputDoneTyping:', value); } }
+          defaultValue="lon"
+          onChange={(value) => { console.log('onChange:', value); } }
+          doneTyping={(value) => { console.log('doneTyping:', value); } }
           doneTypingInterval={2000}
           />
       </div>
       <div className="row">
         <InputBoxDoneTyping
-          inputDoneTyping={(value) => { console.log('inputDoneTyping:', value); } }
+          doneTyping={(value) => { console.log('doneTyping:', value); } }
           />
       </div>
       <div className="row">
         <InputBoxDoneTyping
-          inputId="input-box-done-typing"
-          inputClassName="form-control"
-          inputPlaceholder="Start typing ..."
-          inputAutoComplete="on"
-          inputDoneTyping={(value) => { console.log('inputDoneTyping:', value); } }
+          id="input-box-done-typing"
+          className="form-control"
+          placeholder="Start typing ..."
+          autoComplete="on"
+          doneTyping={(value) => { console.log('doneTyping:', value); } }
           />
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babelify": "^7.3.0",
     "chai": "^3.5.0",
     "enzyme": "^2.4.1",
-    "mocha": "^2.5.3",
+    "mocha": "^3.0.1",
     "react-addons-test-utils": "^15.3.0",
     "sinon": "^1.17.5",
     "sinon-chai": "^2.8.0"

--- a/src/InputBoxDoneTyping.js
+++ b/src/InputBoxDoneTyping.js
@@ -2,18 +2,17 @@ import React, {PropTypes} from 'react';
 
 const InputBoxDoneTyping = (props) => {
   let typingTimer;
-  let before = props.inputDefaultValue;
 
   const handleOnChange = (e) => {
-    if (props.inputOnChange) {
+    if (props.onChange) {
       const value = e.target.value;
-      props.inputOnChange(value);
+      props.onChange(value);
     }
   }
 
   const handleOnKeyUp = (e) => {
-    const value = e.target.value;
     clearTimeout(typingTimer);
+    const value = e.target.value;
     typingTimer = setTimeout(() => { doneTyping(value); }, props.doneTypingInterval);
   }
 
@@ -22,20 +21,17 @@ const InputBoxDoneTyping = (props) => {
   }
 
   const doneTyping = (value) => {
-    if (value.toLowerCase() !== before.toLowerCase()) {
-      before = value;
-      props.inputDoneTyping(value);
-    }
+    props.doneTyping(value);
   }
 
   return (
     <input
       type="text"
-      id={props.inputId}
-      className={props.inputClassName}
-      placeholder={props.inputPlaceholder}
-      defaultValue={props.inputDefaultValue}
-      autoComplete={props.inputAutoComplete}
+      id={props.id}
+      className={props.className}
+      placeholder={props.placeholder}
+      defaultValue={props.defaultValue}
+      autoComplete={props.autoComplete}
       onChange={handleOnChange}
       onKeyUp={handleOnKeyUp}
       onKeyDown={handleOnKeyDown}
@@ -44,22 +40,18 @@ const InputBoxDoneTyping = (props) => {
 }
 
 InputBoxDoneTyping.defaultProps = {
-  inputId: '',
-  inputClassName: '',
-  inputPlaceholder: '',
-  inputDefaultValue: '',
-  inputAutoComplete: 'on',
+  autoComplete: 'on',
   doneTypingInterval: 500
 };
 
 InputBoxDoneTyping.propTypes = {
-  inputId: PropTypes.string,
-  inputClassName: PropTypes.string,
-  inputPlaceholder: PropTypes.string,
-  inputDefaultValue: PropTypes.string,
-  inputAutoComplete: PropTypes.oneOf(['on', 'off']),
-  inputOnChange: PropTypes.func,
-  inputDoneTyping: PropTypes.func.isRequired,
+  id: PropTypes.string,
+  className: PropTypes.string,
+  placeholder: PropTypes.string,
+  defaultValue: PropTypes.string,
+  autoComplete: PropTypes.oneOf(['on', 'off']),
+  onChange: PropTypes.func,
+  doneTyping: PropTypes.func.isRequired,
   doneTypingInterval: PropTypes.number
 };
 

--- a/src/InputBoxDoneTyping.spec.js
+++ b/src/InputBoxDoneTyping.spec.js
@@ -17,10 +17,10 @@ describe('<InputBoxDoneTyping />', () => {
 
   beforeEach(() => {
     props = {
-      doneTypingInterval: 5,
-      inputDoneTyping: sinon.spy(),
-      inputOnChange: sinon.spy(),
-      inputDefaultValue: typing.lon
+      defaultValue: typing.lon,
+      onChange: sinon.spy(),
+      doneTyping: sinon.spy(),
+      doneTypingInterval: 5
     };
 
     wrapper = shallow(<InputBoxDoneTyping {...props} />);
@@ -34,30 +34,16 @@ describe('<InputBoxDoneTyping />', () => {
   });
 
   it('should handle change', () => {
-    props.inputOnChange.should.not.have.been.called;
+    props.onChange.should.not.have.been.called;
     wrapper.simulate('change', { target: { value: typing.lon } });
-    props.inputOnChange.should.have.been.calledWith(typing.lon);
+    props.onChange.should.have.been.calledWith(typing.lon);
   });
 
   it('should notify done typing', () => {
-    props.inputDoneTyping.should.not.have.been.called;
+    props.doneTyping.should.not.have.been.called;
     wrapper.simulate('keyup', { target: { value: typing.lond } });
     clock.tick(10);
-    props.inputDoneTyping.should.have.been.calledWith(typing.lond);
-  });
-
-  it('shouldn\'t notify done typing if user input doesn\'t change', () => {
-    props.inputDoneTyping.should.not.have.been.called;
-    wrapper.simulate('keyup', { target: { value: typing.lon } });
-    clock.tick(10);
-    props.inputDoneTyping.should.not.have.been.calledWith(typing.lon);
-  });
-
-  it('shouldn\'t notify done typing if user input changes capitalisation only', () => {
-    props.inputDoneTyping.should.not.have.been.called;
-    wrapper.simulate('keyup', { target: { value: typing.lon.toUpperCase() } });
-    clock.tick(10);
-    props.inputDoneTyping.should.not.have.been.calledWith(typing.lon);
+    props.doneTyping.should.have.been.calledWith(typing.lond);
   });
 
   afterEach(() => {


### PR DESCRIPTION
# Description
- remove the "input" prefix from the name of the properties as they are already in an `<input />` element context
- remove also the logic that was checking if the actual value has changed before raising the deferred `doneTyping` callback; it should be consumer's concern deciding whether or not to discard this info

this PR will fix #3 
